### PR TITLE
Cleanup and widespread implementation

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/event/Event.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/event/Event.kt
@@ -27,5 +27,6 @@ open class CancellableEvent : Event() {
 }
 
 enum class EventState(val stateName: String) {
-    PRE("PRE"), POST("POST")
+    PRE("PRE"), POST("POST"), // MotionEvent
+    SEND("SEND"), RECEIVE("RECEIVE") // PacketEvent
 }

--- a/src/main/java/net/ccbluex/liquidbounce/event/Events.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/event/Events.kt
@@ -108,7 +108,7 @@ class MoveEvent(var x: Double, var y: Double, var z: Double) : CancellableEvent(
 /**
  * Called when receive or send a packet
  */
-class PacketEvent(val packet: Packet<*>) : CancellableEvent()
+class PacketEvent(val packet: Packet<*>, val eventType: EventState) : CancellableEvent()
 
 /**
  * Called when a block tries to push you

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/EnchantCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/EnchantCommand.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.minecraft.enchantment.Enchantment
 import net.minecraft.network.play.client.C10PacketCreativeInventoryAction
 
@@ -55,7 +56,7 @@ class EnchantCommand : Command("enchant") {
             }
 
             item.addEnchantment(enchantment, level)
-            mc.netHandler.addToSendQueue(C10PacketCreativeInventoryAction(36 + mc.thePlayer.inventory.currentItem, item))
+            sendPacket(C10PacketCreativeInventoryAction(36 + mc.thePlayer.inventory.currentItem, item))
             chat("${enchantment.getTranslatedName(level)} added to ${item.displayName}.")
             return
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/GiveCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/GiveCommand.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.item.ItemUtils
 import net.ccbluex.liquidbounce.utils.misc.StringUtils
 import net.minecraft.item.Item
@@ -50,7 +51,7 @@ class GiveCommand : Command("give", "item", "i", "get") {
             }
 
             if (emptySlot != -1) {
-                mc.netHandler.addToSendQueue(C10PacketCreativeInventoryAction(emptySlot, itemStack))
+                sendPacket(C10PacketCreativeInventoryAction(emptySlot, itemStack))
                 chat("§7Given [§8${itemStack.displayName}§7] * §8${itemStack.stackSize}§7 to §8${mc.session.username}§7.")
             } else
                 chat("Your inventory is full.")

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/HoloStandCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/HoloStandCommand.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.misc.StringUtils
 import net.minecraft.init.Items
 import net.minecraft.item.ItemStack
@@ -46,7 +47,7 @@ class HoloStandCommand : Command("holostand") {
                 base.setTag("EntityTag", entityTag)
                 itemStack.tagCompound = base
                 itemStack.setStackDisplayName("§c§lHolo§eStand")
-                mc.netHandler.addToSendQueue(C10PacketCreativeInventoryAction(36, itemStack))
+                sendPacket(C10PacketCreativeInventoryAction(36, itemStack))
 
                 chat("The HoloStand was successfully added to your inventory.")
             } catch (exception: NumberFormatException) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/HurtCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/HurtCommand.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 
 class HurtCommand : Command("hurt") {
@@ -30,10 +31,10 @@ class HurtCommand : Command("hurt") {
         val z = mc.thePlayer.posZ
 
         for (i in 0 until 65 * damage) {
-            mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.049, z, false))
-            mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, false))
+            sendPacket(C04PacketPlayerPosition(x, y + 0.049, z, false))
+            sendPacket(C04PacketPlayerPosition(x, y, z, false))
         }
-        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, true))
+        sendPacket(C04PacketPlayerPosition(x, y, z, true))
 
         // Output message
         chat("You were damaged.")

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/RenameCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/RenameCommand.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.misc.StringUtils
 import net.ccbluex.liquidbounce.utils.render.ColorUtils
 import net.minecraft.network.play.client.C10PacketCreativeInventoryAction
@@ -29,7 +30,7 @@ class RenameCommand : Command("rename") {
             }
 
             item.setStackDisplayName(ColorUtils.translateAlternateColorCodes(StringUtils.toCompleteString(args, 1)))
-            mc.netHandler.addToSendQueue(C10PacketCreativeInventoryAction(36 + mc.thePlayer.inventory.currentItem, item))
+            sendPacket(C10PacketCreativeInventoryAction(36 + mc.thePlayer.inventory.currentItem, item))
             chat("§3Item renamed to '${item.displayName}§3'")
             return
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoBow.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoBow.kt
@@ -9,9 +9,11 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.minecraft.item.ItemBow
 import net.minecraft.network.play.client.C07PacketPlayerDigging
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.RELEASE_USE_ITEM
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
 
@@ -26,7 +28,7 @@ object AutoBow : Module("AutoBow", category = ModuleCategory.COMBAT) {
         if (thePlayer.isUsingItem && thePlayer.heldItem?.item is ItemBow &&
                 thePlayer.itemInUseDuration > 20 && (!waitForBowAimbot.get() || !BowAimbot.state || BowAimbot.hasTarget())) {
             thePlayer.stopUsingItem()
-            mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.RELEASE_USE_ITEM, BlockPos.ORIGIN, EnumFacing.DOWN))
+            sendPacket(C07PacketPlayerDigging(RELEASE_USE_ITEM, BlockPos.ORIGIN, EnumFacing.DOWN))
         }
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoLeave.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoLeave.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextInt
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.ListValue
@@ -26,8 +27,8 @@ object AutoLeave : Module("AutoLeave", category = ModuleCategory.COMBAT) {
         if (thePlayer.health <= healthValue.get() && !thePlayer.capabilities.isCreativeMode && !mc.isIntegratedServerRunning) {
             when (modeValue.get().lowercase()) {
                 "quit" -> mc.theWorld.sendQuittingDisconnectingPacket()
-                "invalidpacket" -> mc.netHandler.addToSendQueue(C04PacketPlayerPosition(Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, !mc.thePlayer.onGround))
-                "selfhurt" -> mc.netHandler.addToSendQueue(C02PacketUseEntity(mc.thePlayer, C02PacketUseEntity.Action.ATTACK))
+                "invalidpacket" -> sendPacket(C04PacketPlayerPosition(Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, !mc.thePlayer.onGround))
+                "selfhurt" -> sendPacket(C02PacketUseEntity(mc.thePlayer, C02PacketUseEntity.Action.ATTACK))
                 "illegalchat" -> thePlayer.sendChatMessage(nextInt().toString() + "§§§" + nextInt())
             }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.event.MotionEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.InventoryUtils
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.Rotation
 import net.ccbluex.liquidbounce.utils.RotationUtils.serverRotation
 import net.ccbluex.liquidbounce.utils.RotationUtils.setTargetRotation
@@ -28,6 +29,7 @@ import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement
 import net.minecraft.network.play.client.C09PacketHeldItemChange
 import net.minecraft.network.play.client.C0DPacketCloseWindow
 import net.minecraft.network.play.client.C16PacketClientStatus
+import net.minecraft.network.play.client.C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT
 import net.minecraft.potion.Potion
 
 object AutoPot : Module("AutoPot", category = ModuleCategory.COMBAT) {
@@ -75,7 +77,7 @@ object AutoPot : Module("AutoPot", category = ModuleCategory.COMBAT) {
                         return
 
                     potion = potionInHotbar
-                    mc.netHandler.addToSendQueue(C09PacketHeldItemChange(potion - 36))
+                    sendPacket(C09PacketHeldItemChange(potion - 36))
 
                     if (thePlayer.rotationPitch <= 80F) {
                         setTargetRotation(
@@ -94,12 +96,12 @@ object AutoPot : Module("AutoPot", category = ModuleCategory.COMBAT) {
                     val openInventory = mc.currentScreen !is GuiInventory && simulateInventory.get()
 
                     if (openInventory)
-                        mc.netHandler.addToSendQueue(C16PacketClientStatus(C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT))
+                        sendPacket(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
 
                     mc.playerController.windowClick(0, potionInInventory, 0, 1, thePlayer)
 
                     if (openInventory)
-                        mc.netHandler.addToSendQueue(C0DPacketCloseWindow())
+                        sendPacket(C0DPacketCloseWindow())
 
                     msTimer.reset()
                 }
@@ -109,8 +111,8 @@ object AutoPot : Module("AutoPot", category = ModuleCategory.COMBAT) {
                     val itemStack = thePlayer.inventoryContainer.getSlot(potion).stack
 
                     if (itemStack != null) {
-                        mc.netHandler.addToSendQueue(C08PacketPlayerBlockPlacement(itemStack))
-                        mc.netHandler.addToSendQueue(C09PacketHeldItemChange(thePlayer.inventory.currentItem))
+                        sendPacket(C08PacketPlayerBlockPlacement(itemStack))
+                        sendPacket(C09PacketHeldItemChange(thePlayer.inventory.currentItem))
 
                         msTimer.reset()
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoSoup.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoSoup.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.InventoryUtils
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
@@ -18,6 +19,8 @@ import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraft.init.Items
 import net.minecraft.network.play.client.*
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.DROP_ITEM
+import net.minecraft.network.play.client.C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
 
@@ -46,14 +49,14 @@ object AutoSoup : Module("AutoSoup", category = ModuleCategory.COMBAT) {
         val soupInHotbar = InventoryUtils.findItem(36, 45, Items.mushroom_stew)
 
         if (thePlayer.health <= healthValue.get() && soupInHotbar != -1) {
-            mc.netHandler.addToSendQueue(C09PacketHeldItemChange(soupInHotbar - 36))
-            mc.netHandler.addToSendQueue(C08PacketPlayerBlockPlacement(thePlayer.inventory.getStackInSlot(soupInHotbar)))
+            sendPacket(C09PacketHeldItemChange(soupInHotbar - 36))
+            sendPacket(C08PacketPlayerBlockPlacement(thePlayer.inventory.getStackInSlot(soupInHotbar)))
 
             if (bowlValue.get() == "Drop")
-                mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.DROP_ITEM,
+                sendPacket(C07PacketPlayerDigging(DROP_ITEM,
                     BlockPos.ORIGIN, EnumFacing.DOWN))
 
-            mc.netHandler.addToSendQueue(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
+            sendPacket(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
             timer.reset()
             return
         }
@@ -81,7 +84,7 @@ object AutoSoup : Module("AutoSoup", category = ModuleCategory.COMBAT) {
                 val openInventory = mc.currentScreen !is GuiInventory && simulateInventoryValue.get()
 
                 if (openInventory)
-                    mc.netHandler.addToSendQueue(C16PacketClientStatus(C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT))
+                    sendPacket(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
 
                 mc.playerController.windowClick(0, bowlInHotbar, 0, 1, thePlayer)
             }
@@ -95,12 +98,12 @@ object AutoSoup : Module("AutoSoup", category = ModuleCategory.COMBAT) {
 
             val openInventory = mc.currentScreen !is GuiInventory && simulateInventoryValue.get()
             if (openInventory)
-                mc.netHandler.addToSendQueue(C16PacketClientStatus(C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT))
+                sendPacket(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
 
             mc.playerController.windowClick(0, soupInInventory, 0, 1, thePlayer)
 
             if (openInventory)
-                mc.netHandler.addToSendQueue(C0DPacketCloseWindow())
+                sendPacket(C0DPacketCloseWindow())
 
             timer.reset()
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoWeapon.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoWeapon.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.item.ItemUtils
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.IntegerValue
@@ -55,7 +56,7 @@ object AutoWeapon : Module("AutoWeapon", category = ModuleCategory.COMBAT) {
 
             // Switch to best weapon
             if (silentValue.get()) {
-                mc.netHandler.addToSendQueue(C09PacketHeldItemChange(slot))
+                sendPacket(C09PacketHeldItemChange(slot))
                 spoofedSlot = ticksValue.get()
             } else {
                 mc.thePlayer.inventory.currentItem = slot
@@ -63,7 +64,7 @@ object AutoWeapon : Module("AutoWeapon", category = ModuleCategory.COMBAT) {
             }
 
             // Resend attack packet
-            mc.netHandler.addToSendQueue(event.packet)
+            sendPacket(event.packet)
             event.cancelEvent()
         }
     }
@@ -73,7 +74,7 @@ object AutoWeapon : Module("AutoWeapon", category = ModuleCategory.COMBAT) {
         // Switch back to old item after some time
         if (spoofedSlot > 0) {
             if (spoofedSlot == 1)
-                mc.netHandler.addToSendQueue(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
+                sendPacket(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
             spoofedSlot--
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/Criticals.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.movement.Fly
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
 import net.ccbluex.liquidbounce.value.IntegerValue
 import net.ccbluex.liquidbounce.value.ListValue
@@ -48,16 +49,16 @@ object Criticals : Module("Criticals", category = ModuleCategory.COMBAT) {
 
             when (modeValue.get().lowercase()) {
                 "packet" -> {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.0625, z, true))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, false))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 1.1E-5, z, false))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.0625, z, true))
+                    sendPacket(C04PacketPlayerPosition(x, y, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 1.1E-5, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y, z, false))
                     thePlayer.onCriticalHit(entity)
                 }
                 "ncppacket" -> {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.11, z, false))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.1100013579, z, false))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.0000013579, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.11, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.1100013579, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.0000013579, z, false))
                     mc.thePlayer.onCriticalHit(entity)
                 }
                 "hop" -> {
@@ -66,8 +67,8 @@ object Criticals : Module("Criticals", category = ModuleCategory.COMBAT) {
                     thePlayer.onGround = false
                 }
                 "tphop" -> {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.02, z, false))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.01, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.02, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.01, z, false))
                     thePlayer.setPosition(x, y + 0.01, z)
                 }
                 "jump" -> thePlayer.motionY = 0.42

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/FastBow.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/FastBow.kt
@@ -9,11 +9,13 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.targetRotation
 import net.ccbluex.liquidbounce.value.IntegerValue
 import net.minecraft.item.ItemBow
 import net.minecraft.network.play.client.C03PacketPlayer.C05PacketPlayerLook
 import net.minecraft.network.play.client.C07PacketPlayerDigging
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.RELEASE_USE_ITEM
 import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
@@ -32,16 +34,16 @@ object FastBow : Module("FastBow", category = ModuleCategory.COMBAT) {
         val currentItem = thePlayer.inventory.getCurrentItem()
 
         if (currentItem != null && currentItem.item is ItemBow) {
-            mc.netHandler.addToSendQueue(C08PacketPlayerBlockPlacement(BlockPos.ORIGIN, 255, mc.thePlayer.currentEquippedItem, 0F, 0F, 0F))
+            sendPacket(C08PacketPlayerBlockPlacement(BlockPos.ORIGIN, 255, mc.thePlayer.currentEquippedItem, 0F, 0F, 0F))
 
             val yaw = targetRotation?.yaw ?: thePlayer.rotationYaw
 
             val pitch = targetRotation?.pitch ?: thePlayer.rotationPitch
 
             for (i in 0 until packetsValue.get())
-                mc.netHandler.addToSendQueue(C05PacketPlayerLook(yaw, pitch, true))
+                sendPacket(C05PacketPlayerLook(yaw, pitch, true))
 
-            mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.RELEASE_USE_ITEM, BlockPos.ORIGIN, EnumFacing.DOWN))
+            sendPacket(C07PacketPlayerDigging(RELEASE_USE_ITEM, BlockPos.ORIGIN, EnumFacing.DOWN))
             thePlayer.itemInUseCount = currentItem.maxItemUseDuration - 1
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/SuperKnockback.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/SuperKnockback.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.AttackEvent
 import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.IntegerValue
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.network.play.client.C0BPacketEntityAction
@@ -24,11 +25,11 @@ object SuperKnockback : Module("SuperKnockback", ModuleCategory.COMBAT) {
                 return
 
             if (mc.thePlayer.isSprinting)
-                mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SPRINTING))
+                sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SPRINTING))
 
-            mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SPRINTING))
-            mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SPRINTING))
-            mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SPRINTING))
+            sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SPRINTING))
+            sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SPRINTING))
+            sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SPRINTING))
             mc.thePlayer.isSprinting = true
             mc.thePlayer.serverSprintState = true
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Clip.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Clip.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
@@ -31,19 +32,17 @@ object Clip : Module("Clip", category = ModuleCategory.EXPLOIT, canEnable = fals
                     thePlayer.posZ + z)
 
             "flag" -> {
-                val netHandler = mc.netHandler
-
-                netHandler.addToSendQueue(C04PacketPlayerPosition(mc.thePlayer.posX,
+                sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX,
                     mc.thePlayer.posY, mc.thePlayer.posZ, true))
-                netHandler.addToSendQueue(C04PacketPlayerPosition(0.5, 0.0,
+                sendPacket(C04PacketPlayerPosition(0.5, 0.0,
                     0.5, true))
-                netHandler.addToSendQueue(C04PacketPlayerPosition(mc.thePlayer.posX,
+                sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX,
                     mc.thePlayer.posY, mc.thePlayer.posZ, true))
-                netHandler.addToSendQueue(C04PacketPlayerPosition(mc.thePlayer.posX + x,
+                sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX + x,
                     mc.thePlayer.posY + verticalValue.get(), mc.thePlayer.posZ + z, true))
-                netHandler.addToSendQueue(C04PacketPlayerPosition(0.5,
+                sendPacket(C04PacketPlayerPosition(0.5,
                     0.0, 0.5, true))
-                netHandler.addToSendQueue(C04PacketPlayerPosition(mc.thePlayer.posX
+                sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX
                         + 0.5, mc.thePlayer.posY, mc.thePlayer.posZ + 0.5, true))
 
                 mc.thePlayer.setPosition(mc.thePlayer.posX + -sin(yaw) * 0.04, mc.thePlayer.posY,

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ConsoleSpammer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ConsoleSpammer.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.event.WorldEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextInt
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
 import net.ccbluex.liquidbounce.value.IntegerValue
@@ -43,7 +44,7 @@ object ConsoleSpammer : Module("ConsoleSpammer", ModuleCategory.EXPLOIT) {
             return
 
         when (modeValue.get().lowercase()) {
-            "payload" -> mc.netHandler.addToSendQueue(C17PacketCustomPayload(vulnerableChannels.random(), payload))
+            "payload" -> sendPacket(C17PacketCustomPayload(vulnerableChannels.random(), payload))
             "minesecure" -> {
                 mc.gameSettings.setModelPartEnabled(EnumPlayerModelParts.HAT, nextBoolean())
                 mc.gameSettings.setModelPartEnabled(EnumPlayerModelParts.JACKET, nextBoolean())
@@ -53,8 +54,8 @@ object ConsoleSpammer : Module("ConsoleSpammer", ModuleCategory.EXPLOIT) {
                 mc.gameSettings.setModelPartEnabled(EnumPlayerModelParts.RIGHT_SLEEVE, nextBoolean())
 
                 repeat(5) {
-                    mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
-                    mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
+                    sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
+                    sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
                 }
             }
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Damage.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.IntegerValue
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
@@ -26,10 +27,10 @@ object Damage : Module("Damage", ModuleCategory.EXPLOIT, canEnable = false) {
                 val z = thePlayer.posZ
 
                 repeat(65 * damageValue.get()) {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.049, z, false))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.049, z, false))
+                    sendPacket(C04PacketPlayerPosition(x, y, z, false))
                 }
-                mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, true))
+                sendPacket(C04PacketPlayerPosition(x, y, z, true))
             }
             "aac" -> thePlayer.motionY = 5 * damageValue.get().toDouble()
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/GodMode.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/GodMode.kt
@@ -9,13 +9,14 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
-import net.minecraft.network.play.client.C03PacketPlayer
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
+import net.minecraft.network.play.client.C03PacketPlayer.C06PacketPlayerPosLook
 
 object GodMode : Module("GodMode", ModuleCategory.EXPLOIT) {
 
     @EventTarget
     fun onUpdate(event: UpdateEvent) {
-        mc.netHandler.addToSendQueue(C03PacketPlayer.C06PacketPlayerPosLook(mc.thePlayer.posX,
+        sendPacket(C06PacketPlayerPosLook(mc.thePlayer.posX,
             mc.thePlayer.posY - 0.1, mc.thePlayer.posZ, mc.thePlayer.rotationYaw, mc.thePlayer.rotationPitch, true))
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/KeepContainer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/KeepContainer.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.event.ScreenEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.client.gui.inventory.GuiInventory
 import net.minecraft.network.play.client.C0DPacketCloseWindow
@@ -22,7 +23,7 @@ object KeepContainer : Module("KeepContainer", ModuleCategory.EXPLOIT) {
 
     override fun onDisable() {
         if (container != null)
-            mc.netHandler.addToSendQueue(C0DPacketCloseWindow(container!!.inventorySlots.windowId))
+            sendPacket(C0DPacketCloseWindow(container!!.inventorySlots.windowId))
 
         container = null
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Kick.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Kick.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.exploit
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.ClientUtils.displayChatMessage
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextInt
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.network.play.client.C02PacketUseEntity
@@ -26,12 +27,12 @@ object Kick : Module("Kick", ModuleCategory.EXPLOIT, canEnable = false) {
 
         when (modeValue.get().lowercase()) {
             "quit" -> mc.theWorld.sendQuittingDisconnectingPacket()
-            "invalidpacket" -> mc.netHandler.addToSendQueue(C04PacketPlayerPosition(Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, !mc.thePlayer.onGround))
-            "selfhurt" -> mc.netHandler.addToSendQueue(C02PacketUseEntity(mc.thePlayer, C02PacketUseEntity.Action.ATTACK))
+            "invalidpacket" -> sendPacket(C04PacketPlayerPosition(Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, !mc.thePlayer.onGround))
+            "selfhurt" -> sendPacket(C02PacketUseEntity(mc.thePlayer, C02PacketUseEntity.Action.ATTACK))
             "illegalchat" -> mc.thePlayer.sendChatMessage(nextInt().toString() + "§§§" + nextInt())
             "packetspam" -> {
                 repeat(9999) {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(it.toDouble(), it.toDouble(), it.toDouble(), nextBoolean()))
+                    sendPacket(C04PacketPlayerPosition(it.toDouble(), it.toDouble(), it.toDouble(), nextBoolean()))
                 }
             }
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/PingSpoof.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/PingSpoof.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.timer.TimeUtils.randomDelay
 import net.ccbluex.liquidbounce.value.IntegerValue
 import net.minecraft.network.Packet
@@ -61,7 +62,7 @@ object PingSpoof : Module("PingSpoof", ModuleCategory.EXPLOIT) {
         }
 
         for (packet in filtered) {
-            mc.netHandler.addToSendQueue(packet)
+            sendPacket(packet)
             packetQueue.remove(packet)
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Plugins.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/Plugins.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.ClientUtils.displayChatMessage
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.timer.TickTimer
 import net.minecraft.network.play.client.C14PacketTabComplete
 import net.minecraft.network.play.server.S3APacketTabComplete
@@ -23,7 +24,7 @@ object Plugins : Module("Plugins", ModuleCategory.EXPLOIT) {
         if (mc.thePlayer == null)
             return
 
-        mc.netHandler.addToSendQueue(C14PacketTabComplete("/"))
+        sendPacket(C14PacketTabComplete("/"))
         tickTimer.reset()
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ServerCrasher.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/ServerCrasher.kt
@@ -9,6 +9,7 @@ import io.netty.buffer.Unpooled
 import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.randomNumber
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.randomString
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
@@ -53,7 +54,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 // Spam positions
                 var index = 0
                 while (index < 9999) {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(
+                    sendPacket(C04PacketPlayerPosition(
                             thePlayer.posX + 9412 * index,
                             thePlayer.entityBoundingBox.minY + 9412 * index,
                             thePlayer.posZ + 9412 * index,
@@ -66,7 +67,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 // Spam positions
                 var index = 0
                 while (index < 9999) {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(
+                    sendPacket(C04PacketPlayerPosition(
                             thePlayer.posX + 500000 * index,
                             thePlayer.entityBoundingBox.minY + 500000 * index,
                             thePlayer.posZ + 500000 * index,
@@ -77,7 +78,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
             }
             "aacold" -> {
                 // Send negative infinity position
-                mc.netHandler.addToSendQueue(C04PacketPlayerPosition(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, true))
+                sendPacket(C04PacketPlayerPosition(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, true))
             }
             "worldedit" -> {
                 // Send crash command
@@ -91,7 +92,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 // Fly up into sky
                 var yPos = thePlayer.posY
                 while (yPos < 255) {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(thePlayer.posX,
+                    sendPacket(C04PacketPlayerPosition(thePlayer.posX,
                             yPos, thePlayer.posZ, true))
                     yPos += 5.0
                 }
@@ -99,7 +100,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 // Fly over world
                 var i = 0
                 while (i < 1337 * 5) {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(
+                    sendPacket(C04PacketPlayerPosition(
                             thePlayer.posX + i, 255.0, thePlayer.posZ + i, true
                     ))
                     i += 5
@@ -121,7 +122,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 val pb = PacketBuffer(Unpooled.buffer())
                 pb.writeItemStackToBuffer(book)
 
-                mc.netHandler.addToSendQueue(C17PacketCustomPayload("MC|BSign", pb))
+                sendPacket(C17PacketCustomPayload("MC|BSign", pb))
             }
             "bedit" -> {
                 val tag = NBTTagCompound()
@@ -139,7 +140,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 val pb = PacketBuffer(Unpooled.buffer())
                 pb.writeItemStackToBuffer(book)
 
-                mc.netHandler.addToSendQueue(C17PacketCustomPayload("MC|BEdit", pb))
+                sendPacket(C17PacketCustomPayload("MC|BEdit", pb))
             }
             "netty" -> {
                 val size = "................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."
@@ -163,7 +164,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                     book3.setTagInfo("pages", list3)
                 }
 
-                mc.netHandler.addToSendQueue(C08PacketPlayerBlockPlacement(BlockPos(mc.thePlayer).down(2), 1, book3, 0f, 0f, 0f))
+                sendPacket(C08PacketPlayerBlockPlacement(BlockPos(mc.thePlayer).down(2), 1, book3, 0f, 0f, 0f))
             }
             "netty2" -> {
                 val size2 = "................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."
@@ -190,7 +191,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 thread {
                     while (mc.netHandler.networkManager.isChannelOpen) {
 
-                        mc.netHandler.addToSendQueue(C10PacketCreativeInventoryAction(100, book4))
+                        sendPacket(C10PacketCreativeInventoryAction(100, book4))
                         try {
                             sleep(10L)
                         } catch (e: InterruptedException) {
@@ -231,7 +232,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 for (i in 0..99) {
                     val packetBuffer = PacketBuffer(Unpooled.buffer())
                     packetBuffer.writeItemStackToBuffer(bookStack)
-                    mc.netHandler.addToSendQueue(C17PacketCustomPayload(if (nextBoolean()) "MC|BSign" else "MC|BEdit", packetBuffer))
+                    sendPacket(C17PacketCustomPayload(if (nextBoolean()) "MC|BSign" else "MC|BEdit", packetBuffer))
                 }
             }
             "cubecraft" -> {
@@ -240,9 +241,9 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
                 val z = thePlayer.posZ
                 var i = 0
                 while (i < 3000) {
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x,
+                    sendPacket(C04PacketPlayerPosition(x,
                             y + 0.09999999999999, z, false))
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, true))
+                    sendPacket(C04PacketPlayerPosition(x, y, z, true))
                     ++i
                 }
                 thePlayer.motionY = 0.0
@@ -255,7 +256,7 @@ object ServerCrasher : Module("ServerCrasher", ModuleCategory.EXPLOIT) {
             "swing" -> {
                 var i = 0
                 while (i < 5000) {
-                    mc.netHandler.addToSendQueue(C0APacketAnimation())
+                    sendPacket(C0APacketAnimation())
                     i++
                 }
             }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/VehicleOneHit.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/exploit/VehicleOneHit.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.AttackEvent
 import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.minecraft.entity.item.EntityBoat
 import net.minecraft.entity.item.EntityMinecart
 import net.minecraft.network.play.client.C02PacketUseEntity
@@ -20,8 +21,8 @@ object VehicleOneHit : Module("VehicleOneHit", ModuleCategory.EXPLOIT) {
     fun onAttack(event: AttackEvent) {
         if (event.targetEntity is EntityBoat || event.targetEntity is EntityMinecart) {
             for (i in 0..3) {
-                mc.netHandler.addToSendQueue(C0APacketAnimation())
-                mc.netHandler.addToSendQueue(C02PacketUseEntity(event.targetEntity,
+                sendPacket(C0APacketAnimation())
+                sendPacket(C02PacketUseEntity(event.targetEntity,
                     C02PacketUseEntity.Action.ATTACK))
             }
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/NoRotateSet.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/NoRotateSet.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.serverRotation
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.minecraft.network.play.client.C03PacketPlayer.C05PacketPlayerLook
@@ -35,7 +36,7 @@ object NoRotateSet : Module("NoRotateSet", ModuleCategory.MISC) {
                     packet.yaw != serverRotation.yaw && packet.pitch != serverRotation.pitch) {
 
                 if (confirmValue.get())
-                    mc.netHandler.addToSendQueue(C05PacketPlayerLook(packet.yaw, packet.pitch, thePlayer.onGround))
+                    sendPacket(C05PacketPlayerLook(packet.yaw, packet.pitch, thePlayer.onGround))
             }
 
             packet.yaw = thePlayer.rotationYaw

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/ResourcePackSpoof.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/misc/ResourcePackSpoof.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.ClientUtils.LOGGER
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.minecraft.network.play.client.C19PacketResourcePackStatus
 import net.minecraft.network.play.server.S48PacketResourcePackSend
 import java.net.URI
@@ -35,13 +36,11 @@ object ResourcePackSpoof : Module("ResourcePackSpoof", ModuleCategory.MISC) {
                 if (isLevelProtocol && (".." in url || !url.endsWith("/resources.zip")))
                     throw URISyntaxException(url, "Invalid levelstorage resourcepack path")
 
-                mc.netHandler.addToSendQueue(C19PacketResourcePackStatus(packet.hash,
-                    C19PacketResourcePackStatus.Action.ACCEPTED))
-                mc.netHandler.addToSendQueue(C19PacketResourcePackStatus(packet.hash,
-                    C19PacketResourcePackStatus.Action.SUCCESSFULLY_LOADED))
+                sendPacket(C19PacketResourcePackStatus(packet.hash, C19PacketResourcePackStatus.Action.ACCEPTED))
+                sendPacket(C19PacketResourcePackStatus(packet.hash, C19PacketResourcePackStatus.Action.SUCCESSFULLY_LOADED))
             } catch (e: URISyntaxException) {
                 LOGGER.error("Failed to handle resource pack", e)
-                mc.netHandler.addToSendQueue(C19PacketResourcePackStatus(hash, C19PacketResourcePackStatus.Action.FAILED_DOWNLOAD))
+                sendPacket(C19PacketResourcePackStatus(hash, C19PacketResourcePackStatus.Action.FAILED_DOWNLOAD))
             }
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BugUp.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/BugUp.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlock
 import net.ccbluex.liquidbounce.utils.misc.FallingPlayer
 import net.ccbluex.liquidbounce.utils.render.RenderUtils.drawFilledBox
@@ -86,11 +87,11 @@ object BugUp : Module("BugUp", ModuleCategory.MOVEMENT) {
                         thePlayer.motionY += 0.1
                         thePlayer.fallDistance = 0F
                     }
-                    "ongroundspoof" -> mc.netHandler.addToSendQueue(C03PacketPlayer(true))
+                    "ongroundspoof" -> sendPacket(C03PacketPlayer(true))
 
                     "motionteleport-flag" -> {
                         thePlayer.setPositionAndUpdate(thePlayer.posX, thePlayer.posY + 1f, thePlayer.posZ)
-                        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true))
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true))
                         thePlayer.motionY = 0.1
 
                         strafe()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Fly.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.utils.ClientUtils.displayChatMessage
 import net.ccbluex.liquidbounce.utils.MovementUtils.direction
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.extensions.eyes
 import net.ccbluex.liquidbounce.utils.misc.RandomUtils.nextDouble
 import net.ccbluex.liquidbounce.utils.render.RenderUtils.drawPlatform
@@ -163,11 +164,11 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                     if (!thePlayer.onGround) return@run
 
                     for (i in 0..64) {
-                        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.049, z, false))
-                        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, false))
+                        sendPacket(C04PacketPlayerPosition(x, y + 0.049, z, false))
+                        sendPacket(C04PacketPlayerPosition(x, y, z, false))
                     }
 
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.1, z, true))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.1, z, true))
 
                     thePlayer.motionX *= 0.1
                     thePlayer.motionZ *= 0.1
@@ -177,8 +178,8 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                     if (!thePlayer.onGround) return@run
 
                     for (i in 0..3) {
-                        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 1.01, z, false))
-                        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, false))
+                        sendPacket(C04PacketPlayerPosition(x, y + 1.01, z, false))
+                        sendPacket(C04PacketPlayerPosition(x, y, z, false))
                     }
 
                     thePlayer.jump()
@@ -186,11 +187,11 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                 }
                 "bugspartan" -> {
                     for (i in 0..64) {
-                        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.049, z, false))
-                        mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y, z, false))
+                        sendPacket(C04PacketPlayerPosition(x, y + 0.049, z, false))
+                        sendPacket(C04PacketPlayerPosition(x, y, z, false))
                     }
 
-                    mc.netHandler.addToSendQueue(C04PacketPlayerPosition(x, y + 0.1, z, true))
+                    sendPacket(C04PacketPlayerPosition(x, y + 0.1, z, true))
 
                     thePlayer.motionX *= 0.1
                     thePlayer.motionZ *= 0.1
@@ -207,44 +208,20 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
 
                     for (i in 0..9) {
                         //Imagine flagging to NCP.
-                        mc.netHandler.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX, thePlayer.posY, thePlayer.posZ, true
-                            )
-                        )
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true))
                     }
 
                     var fallDistance = 3.0125 //add 0.0125 to ensure we get the fall dmg
 
                     while (fallDistance > 0) {
-                        mc.netHandler.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX, thePlayer.posY + 0.0624986421, thePlayer.posZ, false
-                            )
-                        )
-                        mc.netHandler.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX, thePlayer.posY + 0.0625, thePlayer.posZ, false
-                            )
-                        )
-                        mc.netHandler.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX, thePlayer.posY + 0.0624986421, thePlayer.posZ, false
-                            )
-                        )
-                        mc.netHandler.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX, thePlayer.posY + 0.0000013579, thePlayer.posZ, false
-                            )
-                        )
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 0.0624986421, thePlayer.posZ, false))
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 0.0625, thePlayer.posZ, false))
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 0.0624986421, thePlayer.posZ, false))
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 0.0000013579, thePlayer.posZ, false))
                         fallDistance -= 0.0624986421
                     }
 
-                    mc.netHandler.addToSendQueue(
-                        C04PacketPlayerPosition(
-                            thePlayer.posX, thePlayer.posY, thePlayer.posZ, true
-                        )
-                    )
+                    sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, true))
 
                     thePlayer.jump()
 
@@ -342,7 +319,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                     if (mc.gameSettings.keyBindSneak.isKeyDown) aacJump -= 0.2
 
                     if (startY + aacJump > thePlayer.posY) {
-                        mc.netHandler.addToSendQueue(C03PacketPlayer(true))
+                        sendPacket(C03PacketPlayer(true))
                         thePlayer.motionY = 0.8
                         strafe(aacSpeedValue.get())
                     }
@@ -365,7 +342,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                         aac3delay = 0
                     }
                     aac3delay++
-                    if (!noFlag) mc.netHandler.addToSendQueue(
+                    if (!noFlag) sendPacket(
                         C04PacketPlayerPosition(
                             thePlayer.posX, thePlayer.posY, thePlayer.posZ, thePlayer.onGround
                         )
@@ -373,7 +350,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                     if (thePlayer.posY <= 0.0) noFlag = true
                 }
                 "flag" -> {
-                    mc.netHandler.addToSendQueue(
+                    sendPacket(
                         C06PacketPlayerPosLook(
                             thePlayer.posX + thePlayer.motionX * 999,
                             thePlayer.posY + (if (mc.gameSettings.keyBindJump.isKeyDown) 1.5624 else 0.00000001) - if (mc.gameSettings.keyBindSneak.isKeyDown) 0.0624 else 0.00000002,
@@ -383,7 +360,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                             true
                         )
                     )
-                    mc.netHandler.addToSendQueue(
+                    sendPacket(
                         C06PacketPlayerPosLook(
                             thePlayer.posX + thePlayer.motionX * 999,
                             thePlayer.posY - 6969,
@@ -399,7 +376,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                     thePlayer.motionY = 0.0
                 }
                 "keepalive" -> {
-                    mc.netHandler.addToSendQueue(C00PacketKeepAlive())
+                    sendPacket(C00PacketKeepAlive())
                     thePlayer.capabilities.isFlying = false
                     thePlayer.motionY = 0.0
                     thePlayer.motionX = 0.0
@@ -416,16 +393,8 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                     thePlayer.motionZ = 0.0
                     strafe(vanillaSpeed)
                     if (mineSecureVClipTimer.hasTimePassed(150) && mc.gameSettings.keyBindJump.isKeyDown) {
-                        mc.netHandler.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX, thePlayer.posY + 5, thePlayer.posZ, false
-                            )
-                        )
-                        mc.netHandler.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                0.5, -1000.0, 0.5, false
-                            )
-                        )
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY + 5, thePlayer.posZ, false))
+                        sendPacket(C04PacketPlayerPosition(0.5, -1000.0, 0.5, false))
                         val yaw = Math.toRadians(thePlayer.rotationYaw.toDouble())
                         val x = -sin(yaw) * 0.4
                         val z = cos(yaw) * 0.4
@@ -450,16 +419,8 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                         sin(Math.toRadians(pitch.toDouble())) * length + vectorStart.yCoord,
                         cos(Math.toRadians(yaw.toDouble())) * cos(Math.toRadians(pitch.toDouble())) * length + vectorStart.zCoord
                     )
-                    mc.netHandler.addToSendQueue(
-                        C04PacketPlayerPosition(
-                            vectorEnd.xCoord, thePlayer.posY + 2, vectorEnd.zCoord, true
-                        )
-                    )
-                    mc.netHandler.addToSendQueue(
-                        C04PacketPlayerPosition(
-                            vectorStart.xCoord, thePlayer.posY + 2, vectorStart.zCoord, true
-                        )
-                    )
+                    sendPacket(C04PacketPlayerPosition(vectorEnd.xCoord, thePlayer.posY + 2, vectorEnd.zCoord, true))
+                    sendPacket(C04PacketPlayerPosition(vectorStart.xCoord, thePlayer.posY + 2, vectorStart.zCoord, true))
                     thePlayer.motionY = 0.0
                 }
                 "minesucht" -> {
@@ -474,51 +435,19 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                         val vec31: Vec3 = mc.thePlayer.getLook(1f)
                         val vec32: Vec3 = vec3.addVector(vec31.xCoord * 7, vec31.yCoord * 7, vec31.zCoord * 7)
                         if (thePlayer.fallDistance > 0.8) {
-                            thePlayer.sendQueue.addToSendQueue(
-                                C04PacketPlayerPosition(
-                                    posX, posY + 50, posZ, false
-                                )
-                            )
+                            sendPacket(C04PacketPlayerPosition(posX, posY + 50, posZ, false))
                             mc.thePlayer.fall(100f, 100f)
                             thePlayer.fallDistance = 0f
-                            thePlayer.sendQueue.addToSendQueue(
-                                C04PacketPlayerPosition(
-                                    posX, posY + 20, posZ, true
-                                )
-                            )
+                            sendPacket(C04PacketPlayerPosition(posX, posY + 20, posZ, true))
                         }
-                        thePlayer.sendQueue.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                vec32.xCoord, thePlayer.posY + 50, vec32.zCoord, true
-                            )
-                        )
-                        thePlayer.sendQueue.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                posX, posY, posZ, false
-                            )
-                        )
-                        thePlayer.sendQueue.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                vec32.xCoord, posY, vec32.zCoord, true
-                            )
-                        )
-                        thePlayer.sendQueue.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                posX, posY, posZ, false
-                            )
-                        )
+                        sendPacket(C04PacketPlayerPosition(vec32.xCoord, thePlayer.posY + 50, vec32.zCoord, true))
+                        sendPacket(C04PacketPlayerPosition(posX, posY, posZ, false))
+                        sendPacket(C04PacketPlayerPosition(vec32.xCoord, posY, vec32.zCoord, true))
+                        sendPacket(C04PacketPlayerPosition(posX, posY, posZ, false))
                         minesuchtTP = System.currentTimeMillis()
                     } else {
-                        thePlayer.sendQueue.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                thePlayer.posX, thePlayer.posY, thePlayer.posZ, false
-                            )
-                        )
-                        thePlayer.sendQueue.addToSendQueue(
-                            C04PacketPlayerPosition(
-                                posX, posY, posZ, true
-                            )
-                        )
+                        sendPacket(C04PacketPlayerPosition(thePlayer.posX, thePlayer.posY, thePlayer.posZ, false))
+                        sendPacket(C04PacketPlayerPosition(posX, posY, posZ, true))
                     }
                 }
                 "jetpack" -> if (mc.gameSettings.keyBindJump.isKeyDown) {
@@ -600,12 +529,12 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
 
                     spartanTimer.update()
                     if (spartanTimer.hasTimePassed(12)) {
-                        mc.netHandler.addToSendQueue(
+                        sendPacket(
                             C04PacketPlayerPosition(
                                 thePlayer.posX, thePlayer.posY + 8, thePlayer.posZ, true
                             )
                         )
-                        mc.netHandler.addToSendQueue(
+                        sendPacket(
                             C04PacketPlayerPosition(
                                 thePlayer.posX, thePlayer.posY - 8, thePlayer.posZ, true
                             )
@@ -615,7 +544,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                 }
                 "spartan2" -> {
                     strafe(0.264f)
-                    if (thePlayer.ticksExisted % 8 == 0) thePlayer.sendQueue.addToSendQueue(
+                    if (thePlayer.ticksExisted % 8 == 0) sendPacket(
                         C04PacketPlayerPosition(
                             thePlayer.posX, thePlayer.posY + 10, thePlayer.posZ, true
                         )
@@ -841,7 +770,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
         run {
             var posY = mc.thePlayer.posY
             while (posY > ground) {
-                mc.netHandler.addToSendQueue(
+                sendPacket(
                     C04PacketPlayerPosition(
                         mc.thePlayer.posX, posY, mc.thePlayer.posZ, true
                     )
@@ -850,14 +779,14 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
                 posY -= 8.0
             }
         }
-        mc.netHandler.addToSendQueue(
+        sendPacket(
             C04PacketPlayerPosition(
                 mc.thePlayer.posX, ground, mc.thePlayer.posZ, true
             )
         )
         var posY = ground
         while (posY < mc.thePlayer.posY) {
-            mc.netHandler.addToSendQueue(
+            sendPacket(
                 C04PacketPlayerPosition(
                     mc.thePlayer.posX, posY, mc.thePlayer.posZ, true
                 )
@@ -865,7 +794,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
             if (posY + 8.0 > mc.thePlayer.posY) break // Prevent next step
             posY += 8.0
         }
-        mc.netHandler.addToSendQueue(
+        sendPacket(
             C04PacketPlayerPosition(
                 mc.thePlayer.posX, mc.thePlayer.posY, mc.thePlayer.posZ, true
             )
@@ -888,7 +817,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
 
     private fun redeskyHClip2(horizontal: Double) {
         val playerYaw = Math.toRadians(mc.thePlayer.rotationYaw.toDouble())
-        mc.netHandler.addToSendQueue(
+        sendPacket(
             C04PacketPlayerPosition(
                 mc.thePlayer.posX + horizontal * -sin(
                     playerYaw
@@ -898,7 +827,7 @@ object Fly : Module("Fly", ModuleCategory.MOVEMENT, keyBind = Keyboard.KEY_F) {
     }
 
     private fun redeskyVClip2(vertical: Double) {
-        mc.netHandler.addToSendQueue(
+        sendPacket(
             C04PacketPlayerPosition(
                 mc.thePlayer.posX, mc.thePlayer.posY + vertical, mc.thePlayer.posZ, false
             )

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/NoSlow.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/NoSlow.kt
@@ -13,10 +13,12 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.combat.KillAura
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.minecraft.item.*
 import net.minecraft.network.play.client.C07PacketPlayerDigging
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.RELEASE_USE_ITEM
 import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
@@ -55,12 +57,12 @@ object NoSlow : Module("NoSlow", ModuleCategory.MOVEMENT) {
         if (packet.get()) {
             when (event.eventState) {
                 EventState.PRE -> {
-                    val digging = C07PacketPlayerDigging(C07PacketPlayerDigging.Action.RELEASE_USE_ITEM, BlockPos(0, 0, 0), EnumFacing.DOWN)
-                    mc.netHandler.addToSendQueue(digging)
+                    val digging = C07PacketPlayerDigging(RELEASE_USE_ITEM, BlockPos(0, 0, 0), EnumFacing.DOWN)
+                    sendPacket(digging)
                 }
                 EventState.POST -> {
                     val blockPlace = C08PacketPlayerBlockPlacement(BlockPos(-1, -1, -1), 255, mc.thePlayer.heldItem, 0f, 0f, 0f)
-                    mc.netHandler.addToSendQueue(blockPlace)
+                    sendPacket(blockPlace)
                 }
             }
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Sneak.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Sneak.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.event.WorldEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.client.settings.GameSettings
@@ -38,18 +39,18 @@ object Sneak : Module("Sneak", ModuleCategory.MOVEMENT) {
                 if (sneaking)
                     return
 
-                mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
+                sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
             }
 
             "switch" -> {
                 when (event.eventState) {
                     EventState.PRE -> {
-                        mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
-                        mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
+                        sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
+                        sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
                     }
                     EventState.POST -> {
-                        mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
-                        mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
+                        sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.STOP_SNEAKING))
+                        sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
                     }
                 }
             }
@@ -58,7 +59,7 @@ object Sneak : Module("Sneak", ModuleCategory.MOVEMENT) {
                 if (event.eventState == EventState.PRE)
                     return
 
-                mc.netHandler.addToSendQueue(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
+                sendPacket(C0BPacketEntityAction(mc.thePlayer, C0BPacketEntityAction.Action.START_SNEAKING))
             }
         }
     }
@@ -77,7 +78,7 @@ object Sneak : Module("Sneak", ModuleCategory.MOVEMENT) {
                     mc.gameSettings.keyBindSneak.pressed = false
                 }
             }
-            "vanilla", "switch", "minesecure" -> mc.netHandler.addToSendQueue(C0BPacketEntityAction(player, C0BPacketEntityAction.Action.STOP_SNEAKING))
+            "vanilla", "switch", "minesecure" -> sendPacket(C0BPacketEntityAction(player, C0BPacketEntityAction.Action.STOP_SNEAKING))
         }
         sneaking = false
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Step.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/Step.kt
@@ -12,11 +12,13 @@ import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.exploit.Phase
 import net.ccbluex.liquidbounce.utils.MovementUtils.direction
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.ccbluex.liquidbounce.value.IntegerValue
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.network.play.client.C03PacketPlayer
+import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 import net.minecraft.stats.StatList
 import kotlin.math.cos
 import kotlin.math.sin
@@ -196,14 +198,14 @@ object Step : Module("Step", ModuleCategory.MOVEMENT) {
                     fakeJump()
 
                     // Half legit step (1 packet missing) [COULD TRIGGER TOO MANY PACKETS]
-                    mc.netHandler.addToSendQueue(
-                        C03PacketPlayer.C04PacketPlayerPosition(
+                    sendPacket(
+                        C04PacketPlayerPosition(
                             stepX,
                             stepY + 0.41999998688698, stepZ, false
                         )
                     )
-                    mc.netHandler.addToSendQueue(
-                        C03PacketPlayer.C04PacketPlayerPosition(
+                    sendPacket(
+                        C04PacketPlayerPosition(
                             stepX,
                             stepY + 0.7531999805212, stepZ, false
                         )
@@ -215,27 +217,27 @@ object Step : Module("Step", ModuleCategory.MOVEMENT) {
 
                     if (spartanSwitch) {
                         // Vanilla step (3 packets) [COULD TRIGGER TOO MANY PACKETS]
-                        mc.netHandler.addToSendQueue(
-                            C03PacketPlayer.C04PacketPlayerPosition(
+                        sendPacket(
+                            C04PacketPlayerPosition(
                                 stepX,
                                 stepY + 0.41999998688698, stepZ, false
                             )
                         )
-                        mc.netHandler.addToSendQueue(
-                            C03PacketPlayer.C04PacketPlayerPosition(
+                        sendPacket(
+                            C04PacketPlayerPosition(
                                 stepX,
                                 stepY + 0.7531999805212, stepZ, false
                             )
                         )
-                        mc.netHandler.addToSendQueue(
-                            C03PacketPlayer.C04PacketPlayerPosition(
+                        sendPacket(
+                            C04PacketPlayerPosition(
                                 stepX,
                                 stepY + 1.001335979112147, stepZ, false
                             )
                         )
                     } else // Force step
-                        mc.netHandler.addToSendQueue(
-                            C03PacketPlayer.C04PacketPlayerPosition(
+                        sendPacket(
+                            C04PacketPlayerPosition(
                                 stepX,
                                 stepY + 0.6, stepZ, false
                             )
@@ -251,20 +253,20 @@ object Step : Module("Step", ModuleCategory.MOVEMENT) {
                     fakeJump()
 
                     // Vanilla step (3 packets) [COULD TRIGGER TOO MANY PACKETS]
-                    mc.netHandler.addToSendQueue(
-                        C03PacketPlayer.C04PacketPlayerPosition(
+                    sendPacket(
+                        C04PacketPlayerPosition(
                             stepX,
                             stepY + 0.41999998688698, stepZ, false
                         )
                     )
-                    mc.netHandler.addToSendQueue(
-                        C03PacketPlayer.C04PacketPlayerPosition(
+                    sendPacket(
+                        C04PacketPlayerPosition(
                             stepX,
                             stepY + 0.7531999805212, stepZ, false
                         )
                     )
-                    mc.netHandler.addToSendQueue(
-                        C03PacketPlayer.C04PacketPlayerPosition(
+                    sendPacket(
+                        C04PacketPlayerPosition(
                             stepX,
                             stepY + 1.001335979112147, stepZ, false
                         )

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AACGround.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AACGround.kt
@@ -9,7 +9,8 @@ import net.ccbluex.liquidbounce.event.MoveEvent
 import net.ccbluex.liquidbounce.features.module.modules.movement.Speed.aacGroundTimerValue
 import net.ccbluex.liquidbounce.features.module.modules.movement.speeds.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
-import net.minecraft.network.play.client.C03PacketPlayer
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
+import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 
 class AACGround : SpeedMode("AACGround") {
     override fun onUpdate() {
@@ -17,9 +18,7 @@ class AACGround : SpeedMode("AACGround") {
             return
 
         mc.timer.timerSpeed = aacGroundTimerValue.get()
-        mc.netHandler.addToSendQueue(
-            C03PacketPlayer.C04PacketPlayerPosition(mc.thePlayer.posX, mc.thePlayer.posY, mc.thePlayer.posZ, true)
-        )
+        sendPacket(C04PacketPlayerPosition(mc.thePlayer.posX, mc.thePlayer.posY, mc.thePlayer.posZ, true))
     }
 
     override fun onMotion() {}

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AACPort.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/aac/AACPort.kt
@@ -9,9 +9,10 @@ import net.ccbluex.liquidbounce.event.MoveEvent
 import net.ccbluex.liquidbounce.features.module.modules.movement.Speed.portMax
 import net.ccbluex.liquidbounce.features.module.modules.movement.speeds.SpeedMode
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlock
 import net.minecraft.init.Blocks
-import net.minecraft.network.play.client.C03PacketPlayer
+import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 import net.minecraft.util.BlockPos
 import kotlin.math.cos
 import kotlin.math.sin
@@ -33,7 +34,7 @@ class AACPort : SpeedMode("AACPort") {
 
             if (thePlayer.posY < thePlayer.posY.toInt() + 0.5 && getBlock(BlockPos(x, thePlayer.posY, z)) != Blocks.air)
                 break
-            thePlayer.sendQueue.addToSendQueue(C03PacketPlayer.C04PacketPlayerPosition(x, thePlayer.posY, z, true))
+            sendPacket(C04PacketPlayerPosition(x, thePlayer.posY, z, true))
             d += 0.2
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/MineplexGround.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/movement/speeds/other/MineplexGround.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.features.module.modules.movement.speeds.SpeedMod
 import net.ccbluex.liquidbounce.utils.ClientUtils.displayChatMessage
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.minecraft.network.play.client.C09PacketHeldItemChange
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
@@ -26,7 +27,7 @@ class MineplexGround : SpeedMode("MineplexGround") {
         for (i in 36..44) {
             val itemStack = mc.thePlayer.inventory.getStackInSlot(i)
             if (itemStack != null) continue
-            mc.netHandler.addToSendQueue(C09PacketHeldItemChange(i - 36))
+            sendPacket(C09PacketHeldItemChange(i - 36))
             spoofSlot = true
             break
         }
@@ -48,12 +49,12 @@ class MineplexGround : SpeedMode("MineplexGround") {
         if (targetSpeed > speed) speed += targetSpeed / 8
         if (speed >= targetSpeed) speed = targetSpeed
         strafe(speed)
-        if (!spoofSlot) mc.netHandler.addToSendQueue(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
+        if (!spoofSlot) sendPacket(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
     }
 
     override fun onMove(event: MoveEvent) {}
     override fun onDisable() {
         speed = 0f
-        mc.netHandler.addToSendQueue(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
+        sendPacket(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiFireBall.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/AntiFireBall.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.limitAngleChange
 import net.ccbluex.liquidbounce.utils.RotationUtils.serverRotation
 import net.ccbluex.liquidbounce.utils.RotationUtils.setTargetRotation
@@ -63,11 +64,11 @@ object AntiFireBall : Module("AntiFireBall", ModuleCategory.PLAYER) {
                     )
                 )
 
-            mc.thePlayer.sendQueue.addToSendQueue(C02PacketUseEntity(entity, C02PacketUseEntity.Action.ATTACK))
+            sendPacket(C02PacketUseEntity(entity, C02PacketUseEntity.Action.ATTACK))
 
             when (swingValue.get()) {
                 "Normal" -> mc.thePlayer.swingItem()
-                "Packet" -> mc.netHandler.addToSendQueue(C0APacketAnimation())
+                "Packet" -> sendPacket(C0APacketAnimation())
             }
 
             timer.reset()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Blink.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Blink.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.render.Breadcrumbs
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.render.ColorUtils.rainbow
 import net.ccbluex.liquidbounce.utils.render.RenderUtils.glColor
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
@@ -20,6 +21,8 @@ import net.ccbluex.liquidbounce.value.IntegerValue
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.network.Packet
 import net.minecraft.network.play.client.*
+import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
+import net.minecraft.network.play.client.C03PacketPlayer.C06PacketPlayerPosLook
 import org.lwjgl.opengl.GL11.*
 import java.awt.Color
 import java.util.*
@@ -88,7 +91,7 @@ object Blink : Module("Blink", ModuleCategory.PLAYER) {
         if (packet is C03PacketPlayer) // Cancel all movement stuff
             event.cancelEvent()
 
-        if (packet is C03PacketPlayer.C04PacketPlayerPosition || packet is C03PacketPlayer.C06PacketPlayerPosLook ||
+        if (packet is C04PacketPlayerPosition || packet is C06PacketPlayerPosLook ||
             packet is C08PacketPlayerBlockPlacement ||
             packet is C0APacketAnimation ||
             packet is C0BPacketEntityAction || packet is C02PacketUseEntity
@@ -155,9 +158,8 @@ object Blink : Module("Blink", ModuleCategory.PLAYER) {
         try {
             disableLogger = true
 
-            while (!packets.isEmpty()) {
-                mc.netHandler.networkManager.sendPacket(packets.take())
-            }
+            while (!packets.isEmpty())
+                sendPacket(packets.take())
 
             disableLogger = false
         } catch (e: Exception) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/FastUse.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/FastUse.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.event.MoveEvent
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
@@ -59,7 +60,7 @@ object FastUse : Module("FastUse", ModuleCategory.PLAYER) {
             when (modeValue.get().lowercase()) {
                 "instant" -> {
                     repeat(35) {
-                        mc.netHandler.addToSendQueue(C03PacketPlayer(thePlayer.onGround))
+                        sendPacket(C03PacketPlayer(thePlayer.onGround))
                     }
 
                     mc.playerController.onStoppedUsingItem(thePlayer)
@@ -67,7 +68,7 @@ object FastUse : Module("FastUse", ModuleCategory.PLAYER) {
 
                 "ncp" -> if (thePlayer.itemInUseDuration > 14) {
                     repeat(20) {
-                        mc.netHandler.addToSendQueue(C03PacketPlayer(thePlayer.onGround))
+                        sendPacket(C03PacketPlayer(thePlayer.onGround))
                     }
 
                     mc.playerController.onStoppedUsingItem(thePlayer)
@@ -86,7 +87,7 @@ object FastUse : Module("FastUse", ModuleCategory.PLAYER) {
                         return
 
                     repeat(customSpeedValue.get()) {
-                        mc.netHandler.addToSendQueue(C03PacketPlayer(thePlayer.onGround))
+                        sendPacket(C03PacketPlayer(thePlayer.onGround))
                     }
 
                     msTimer.reset()

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/InventoryCleaner.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/InventoryCleaner.kt
@@ -16,6 +16,7 @@ import net.ccbluex.liquidbounce.injection.implementations.IMixinItemStack
 import net.ccbluex.liquidbounce.utils.ClientUtils.LOGGER
 import net.ccbluex.liquidbounce.utils.InventoryUtils
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.item.ArmorPiece
 import net.ccbluex.liquidbounce.utils.item.ItemUtils
 import net.ccbluex.liquidbounce.utils.timer.TimeUtils.randomDelay
@@ -135,13 +136,13 @@ object InventoryCleaner : Module("InventoryCleaner", ModuleCategory.PLAYER) {
             val openInventory = mc.currentScreen !is GuiInventory && simulateInventory.get()
 
             if (openInventory) {
-                mc.netHandler.addToSendQueue(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
+                sendPacket(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
             }
 
             mc.playerController.windowClick(thePlayer.openContainer.windowId, garbageItem, 1, 4, thePlayer)
 
             if (openInventory) {
-                mc.netHandler.addToSendQueue(C0DPacketCloseWindow())
+                sendPacket(C0DPacketCloseWindow())
             }
 
             delay = randomDelay(minDelayValue.get(), maxDelayValue.get())
@@ -224,13 +225,13 @@ object InventoryCleaner : Module("InventoryCleaner", ModuleCategory.PLAYER) {
             if (bestItem != index) {
                 val openInventory = mc.currentScreen !is GuiInventory && simulateInventory.get()
 
-                if (openInventory) mc.netHandler.addToSendQueue(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
+                if (openInventory) sendPacket(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
 
                 mc.playerController.windowClick(
                     0, if (bestItem < 9) bestItem + 36 else bestItem, index, 2, thePlayer
                 )
 
-                if (openInventory) mc.netHandler.addToSendQueue(C0DPacketCloseWindow())
+                if (openInventory) sendPacket(C0DPacketCloseWindow())
 
                 delay = randomDelay(minDelayValue.get(), maxDelayValue.get())
                 break

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/KeepAlive.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/KeepAlive.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 
 import net.ccbluex.liquidbounce.utils.InventoryUtils
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.ListValue
 import net.minecraft.init.Items
 import net.minecraft.network.play.client.C08PacketPlayerBlockPlacement
@@ -35,9 +36,9 @@ object KeepAlive : Module("KeepAlive", ModuleCategory.PLAYER) {
                     val soupInHotbar = InventoryUtils.findItem(36, 45, Items.mushroom_stew)
 
                     if (soupInHotbar != -1) {
-                        mc.netHandler.addToSendQueue(C09PacketHeldItemChange(soupInHotbar - 36))
-                        mc.netHandler.addToSendQueue(C08PacketPlayerBlockPlacement(thePlayer.inventory.getStackInSlot(soupInHotbar)))
-                        mc.netHandler.addToSendQueue(C09PacketHeldItemChange(thePlayer.inventory.currentItem))
+                        sendPacket(C09PacketHeldItemChange(soupInHotbar - 36))
+                        sendPacket(C08PacketPlayerBlockPlacement(thePlayer.inventory.getStackInSlot(soupInHotbar)))
+                        sendPacket(C09PacketHeldItemChange(thePlayer.inventory.currentItem))
                     }
                 }
             }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/NoFall.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/NoFall.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.render.FreeCam
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.faceBlock
 import net.ccbluex.liquidbounce.utils.VecRotation
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.collideBlock
@@ -23,6 +24,7 @@ import net.minecraft.init.Items
 import net.minecraft.item.ItemBlock
 import net.minecraft.item.ItemBucket
 import net.minecraft.network.play.client.C03PacketPlayer
+import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 import net.minecraft.network.play.client.C09PacketHeldItemChange
 import net.minecraft.util.AxisAlignedBB
 import net.minecraft.util.BlockPos
@@ -81,16 +83,16 @@ object NoFall : Module("NoFall", ModuleCategory.PLAYER) {
         when (modeValue.get().lowercase()) {
             "packet" -> {
                 if (mc.thePlayer.fallDistance > 2f) {
-                    mc.netHandler.addToSendQueue(C03PacketPlayer(true))
+                    sendPacket(C03PacketPlayer(true))
                 }
             }
             "cubecraft" -> if (mc.thePlayer.fallDistance > 2f) {
                 mc.thePlayer.onGround = false
-                mc.thePlayer.sendQueue.addToSendQueue(C03PacketPlayer(true))
+                sendPacket(C03PacketPlayer(true))
             }
             "aac" -> {
                 if (mc.thePlayer.fallDistance > 2f) {
-                    mc.netHandler.addToSendQueue(C03PacketPlayer(true))
+                    sendPacket(C03PacketPlayer(true))
                     currentState = 2
                 } else if (currentState == 2 && mc.thePlayer.fallDistance < 2) {
                     mc.thePlayer.motionY = 0.1
@@ -112,21 +114,21 @@ object NoFall : Module("NoFall", ModuleCategory.PLAYER) {
                     }
                 }
             }
-            "laac" -> if (!jumped && mc.thePlayer.onGround && !mc.thePlayer.isOnLadder && !mc.thePlayer.isInWater && !mc.thePlayer.isInWeb) mc.thePlayer.motionY =
-                (-6).toDouble()
+            "laac" -> if (!jumped && mc.thePlayer.onGround && !mc.thePlayer.isOnLadder && !mc.thePlayer.isInWater && !mc.thePlayer.isInWeb)
+                mc.thePlayer.motionY = -6.0
             "aac3.3.11" -> if (mc.thePlayer.fallDistance > 2) {
                 mc.thePlayer.motionZ = 0.0
                 mc.thePlayer.motionX = mc.thePlayer.motionZ
-                mc.netHandler.addToSendQueue(
-                    C03PacketPlayer.C04PacketPlayerPosition(
+                sendPacket(
+                    C04PacketPlayerPosition(
                         mc.thePlayer.posX, mc.thePlayer.posY - 10E-4, mc.thePlayer.posZ, mc.thePlayer.onGround
                     )
                 )
-                mc.netHandler.addToSendQueue(C03PacketPlayer(true))
+                sendPacket(C03PacketPlayer(true))
             }
             "aac3.3.15" -> if (mc.thePlayer.fallDistance > 2) {
-                if (!mc.isIntegratedServerRunning) mc.netHandler.addToSendQueue(
-                    C03PacketPlayer.C04PacketPlayerPosition(
+                if (!mc.isIntegratedServerRunning) sendPacket(
+                    C04PacketPlayerPosition(
                         mc.thePlayer.posX, Double.NaN, mc.thePlayer.posZ, false
                     )
                 )
@@ -135,13 +137,13 @@ object NoFall : Module("NoFall", ModuleCategory.PLAYER) {
             "spartan" -> {
                 spartanTimer.update()
                 if (mc.thePlayer.fallDistance > 1.5 && spartanTimer.hasTimePassed(10)) {
-                    mc.netHandler.addToSendQueue(
-                        C03PacketPlayer.C04PacketPlayerPosition(
+                    sendPacket(
+                        C04PacketPlayerPosition(
                             mc.thePlayer.posX, mc.thePlayer.posY + 10, mc.thePlayer.posZ, true
                         )
                     )
-                    mc.netHandler.addToSendQueue(
-                        C03PacketPlayer.C04PacketPlayerPosition(
+                    sendPacket(
+                        C04PacketPlayerPosition(
                             mc.thePlayer.posX, mc.thePlayer.posY - 10, mc.thePlayer.posZ, true
                         )
                     )
@@ -235,7 +237,7 @@ object NoFall : Module("NoFall", ModuleCategory.PLAYER) {
                 currentMlgBlock = collision.pos
 
                 if (mc.thePlayer.inventory.currentItem != index) {
-                    mc.thePlayer.sendQueue.addToSendQueue(C09PacketHeldItemChange(index))
+                    sendPacket(C09PacketHeldItemChange(index))
                 }
 
                 currentMlgRotation = faceBlock(collision.pos)
@@ -251,7 +253,7 @@ object NoFall : Module("NoFall", ModuleCategory.PLAYER) {
                     mlgTimer.reset()
                 }
             }
-            if (mc.thePlayer.inventory.currentItem != currentMlgItemIndex) mc.thePlayer.sendQueue.addToSendQueue(
+            if (mc.thePlayer.inventory.currentItem != currentMlgItemIndex) sendPacket(
                 C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem)
             )
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Refill.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Refill.kt
@@ -7,6 +7,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.injection.implementations.IMixinItemStack
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.timer.MSTimer
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.IntegerValue
@@ -16,6 +17,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.network.play.client.C0DPacketCloseWindow
 import net.minecraft.network.play.client.C0EPacketClickWindow
 import net.minecraft.network.play.client.C16PacketClientStatus
+import net.minecraft.network.play.client.C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT
 import net.minecraft.network.play.server.S2EPacketCloseWindow
 
 object Refill : Module("Refill", ModuleCategory.PLAYER) {
@@ -99,7 +101,7 @@ object Refill : Module("Refill", ModuleCategory.PLAYER) {
         }
 
         if (simulateInventoryValue.get() && openInv && mc.currentScreen !is GuiInventory)
-            mc.netHandler.addToSendQueue(C0DPacketCloseWindow(mc.thePlayer.openContainer.windowId))
+            sendPacket(C0DPacketCloseWindow(mc.thePlayer.openContainer.windowId))
     }
 
     @EventTarget(ignoreCondition = true)
@@ -109,7 +111,7 @@ object Refill : Module("Refill", ModuleCategory.PLAYER) {
 
         when (packet) {
             is C16PacketClientStatus ->
-                if (packet.status == C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT)
+                if (packet.status == OPEN_INVENTORY_ACHIEVEMENT)
                     openInv = true
             is C0DPacketCloseWindow, is S2EPacketCloseWindow -> openInv = false
         }
@@ -117,9 +119,9 @@ object Refill : Module("Refill", ModuleCategory.PLAYER) {
 
     fun click(slot: Int, button: Int, mode: Int, stack: ItemStack) {
         if (simulateInventoryValue.get() && !openInv)
-            mc.netHandler.addToSendQueue(C16PacketClientStatus(C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT))
+            sendPacket(C16PacketClientStatus(OPEN_INVENTORY_ACHIEVEMENT))
 
-        mc.netHandler.addToSendQueue(
+        sendPacket(
             C0EPacketClickWindow(mc.thePlayer.openContainer.windowId, slot, button, mode, stack,
                 mc.thePlayer.openContainer.getNextTransactionID(mc.thePlayer.inventory))
         )

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Regen.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Regen.kt
@@ -10,6 +10,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.utils.MovementUtils.isMoving
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.IntegerValue
 import net.ccbluex.liquidbounce.value.ListValue
@@ -43,7 +44,7 @@ object Regen : Module("Regen", ModuleCategory.PLAYER) {
             when (modeValue.get().lowercase()) {
                 "vanilla" -> {
                     repeat(speedValue.get()) {
-                        mc.netHandler.addToSendQueue(C03PacketPlayer(mc.thePlayer.onGround))
+                        sendPacket(C03PacketPlayer(mc.thePlayer.onGround))
                     }
                 }
 
@@ -52,7 +53,7 @@ object Regen : Module("Regen", ModuleCategory.PLAYER) {
                         return
 
                     repeat(9) {
-                        mc.netHandler.addToSendQueue(C03PacketPlayer(mc.thePlayer.onGround))
+                        sendPacket(C03PacketPlayer(mc.thePlayer.onGround))
                     }
 
                     mc.timer.timerSpeed = 0.45F

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Zoot.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/player/Zoot.kt
@@ -9,6 +9,7 @@ import net.ccbluex.liquidbounce.event.EventTarget
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.minecraft.network.play.client.C03PacketPlayer
 import net.minecraft.potion.Potion
@@ -31,7 +32,7 @@ object Zoot : Module("Zoot", ModuleCategory.PLAYER) {
 
             if (effect != null) {
                 repeat(effect.duration / 20) {
-                    mc.netHandler.addToSendQueue(C03PacketPlayer(thePlayer.onGround))
+                    sendPacket(C03PacketPlayer(thePlayer.onGround))
                 }
             }
         }
@@ -39,7 +40,7 @@ object Zoot : Module("Zoot", ModuleCategory.PLAYER) {
 
         if (fireValue.get() && !thePlayer.capabilities.isCreativeMode && thePlayer.isBurning) {
             repeat(9) {
-                mc.netHandler.addToSendQueue(C03PacketPlayer(thePlayer.onGround))
+                sendPacket(C03PacketPlayer(thePlayer.onGround))
             }
         }
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/FreeCam.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/render/FreeCam.kt
@@ -10,12 +10,13 @@ import net.ccbluex.liquidbounce.event.PacketEvent
 import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
-import net.ccbluex.liquidbounce.utils.MovementUtils
-import net.ccbluex.liquidbounce.utils.PacketUtils
+import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.network.play.client.C03PacketPlayer
+import net.minecraft.network.play.client.C03PacketPlayer.*
 import net.minecraft.network.play.server.S08PacketPlayerPosLook
 
 object FreeCam : Module("FreeCam", ModuleCategory.RENDER) {
@@ -25,7 +26,7 @@ object FreeCam : Module("FreeCam", ModuleCategory.RENDER) {
     private val motionValue = BoolValue("RecordMotion", true)
     private val c03SpoofValue = BoolValue("C03Spoof", false)
 
-    private var fakePlayer: EntityOtherPlayerMP? = null
+    private lateinit var fakePlayer: EntityOtherPlayerMP
     private var motionX = 0.0
     private var motionY = 0.0
     private var motionZ = 0.0
@@ -46,18 +47,17 @@ object FreeCam : Module("FreeCam", ModuleCategory.RENDER) {
 
         packetCount = 0
         fakePlayer = EntityOtherPlayerMP(mc.theWorld, mc.thePlayer.gameProfile)
-        fakePlayer!!.clonePlayer(mc.thePlayer, true)
-        fakePlayer!!.rotationYawHead = mc.thePlayer.rotationYawHead
-        fakePlayer!!.copyLocationAndAnglesFrom(mc.thePlayer)
-        mc.theWorld.addEntityToWorld(-(Math.random() * 10000).toInt(), fakePlayer)
+        fakePlayer.clonePlayer(mc.thePlayer, true)
+        fakePlayer.rotationYawHead = mc.thePlayer.rotationYawHead
+        fakePlayer.copyLocationAndAnglesFrom(mc.thePlayer)
+        mc.theWorld.addEntityToWorld(-1000, fakePlayer)
         if (noClipValue.get()) mc.thePlayer.noClip = true
     }
 
     override fun onDisable() {
-        if (mc.thePlayer == null || fakePlayer == null) return
-        mc.thePlayer.setPositionAndRotation(fakePlayer!!.posX, fakePlayer!!.posY, fakePlayer!!.posZ, mc.thePlayer.rotationYaw, mc.thePlayer.rotationPitch)
-        mc.theWorld.removeEntityFromWorld(fakePlayer!!.entityId)
-        fakePlayer = null
+        if (mc.thePlayer == null) return
+        mc.thePlayer.setPositionAndRotation(fakePlayer.posX, fakePlayer.posY, fakePlayer.posZ, mc.thePlayer.rotationYaw, mc.thePlayer.rotationPitch)
+        mc.theWorld.removeEntityFromWorld(fakePlayer.entityId)
         mc.thePlayer.motionX = motionX
         mc.thePlayer.motionY = motionY
         mc.thePlayer.motionZ = motionZ
@@ -74,7 +74,7 @@ object FreeCam : Module("FreeCam", ModuleCategory.RENDER) {
             mc.thePlayer.motionZ = 0.0
             if (mc.gameSettings.keyBindJump.isKeyDown) mc.thePlayer.motionY += value.toDouble()
             if (mc.gameSettings.keyBindSneak.isKeyDown) mc.thePlayer.motionY -= value.toDouble()
-            MovementUtils.strafe(value)
+            strafe(value)
         }
     }
 
@@ -82,13 +82,13 @@ object FreeCam : Module("FreeCam", ModuleCategory.RENDER) {
     fun onPacket(event: PacketEvent) {
         val packet = event.packet
         if (c03SpoofValue.get()) {
-            if (packet is C03PacketPlayer.C04PacketPlayerPosition || packet is C03PacketPlayer.C05PacketPlayerLook || packet is C03PacketPlayer.C06PacketPlayerPosLook) {
+            if (packet is C04PacketPlayerPosition || packet is C05PacketPlayerLook || packet is C06PacketPlayerPosLook) {
                 if (packetCount >= 20) {
                     packetCount = 0
-                    PacketUtils.sendPacketNoEvent(C03PacketPlayer.C06PacketPlayerPosLook(fakePlayer!!.posX, fakePlayer!!.posY, fakePlayer!!.posZ, fakePlayer!!.rotationYaw, fakePlayer!!.rotationPitch, fakePlayer!!.onGround))
+                    sendPacket(C06PacketPlayerPosLook(fakePlayer.posX, fakePlayer.posY, fakePlayer.posZ, fakePlayer.rotationYaw, fakePlayer.rotationPitch, fakePlayer.onGround), false)
                 } else {
                     packetCount++
-                    PacketUtils.sendPacketNoEvent(C03PacketPlayer(fakePlayer!!.onGround))
+                    sendPacket(C03PacketPlayer(fakePlayer.onGround), false)
                 }
                 event.cancelEvent()
             }
@@ -97,15 +97,15 @@ object FreeCam : Module("FreeCam", ModuleCategory.RENDER) {
         }
 
         if (packet is S08PacketPlayerPosLook) {
-            fakePlayer!!.setPosition(packet.x, packet.y, packet.z)
-            // when teleport,motion reset
+            fakePlayer.setPosition(packet.x, packet.y, packet.z)
+            // when teleported, reset motion
 
             motionX = 0.0
             motionY = 0.0
             motionZ = 0.0
 
-            // apply the flag to bypass some anticheat
-            PacketUtils.sendPacketNoEvent(C03PacketPlayer.C06PacketPlayerPosLook(fakePlayer!!.posX, fakePlayer!!.posY, fakePlayer!!.posZ, fakePlayer!!.rotationYaw, fakePlayer!!.rotationPitch, fakePlayer!!.onGround))
+            // apply the flag to bypass some anticheats
+            sendPacket(C06PacketPlayerPosLook(fakePlayer.posX, fakePlayer.posY, fakePlayer.posZ, fakePlayer.rotationYaw, fakePlayer.rotationPitch, fakePlayer.onGround), false)
 
             event.cancelEvent()
         }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestAura.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestAura.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.combat.KillAura
 import net.ccbluex.liquidbounce.features.module.modules.player.Blink
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.faceBlock
 import net.ccbluex.liquidbounce.utils.RotationUtils.setTargetRotation
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getCenterDistance
@@ -88,7 +89,7 @@ object ChestAura : Module("ChestAura", ModuleCategory.WORLD) {
                     if (visualSwing.get())
                         thePlayer.swingItem()
                     else
-                        mc.netHandler.addToSendQueue(C0APacketAnimation())
+                        sendPacket(C0APacketAnimation())
 
                     clickedBlocks.add(currentBlock!!)
                     currentBlock = null

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/CivBreak.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/CivBreak.kt
@@ -8,6 +8,7 @@ package net.ccbluex.liquidbounce.features.module.modules.world
 import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.faceBlock
 import net.ccbluex.liquidbounce.utils.RotationUtils.setTargetRotation
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlock
@@ -17,6 +18,8 @@ import net.ccbluex.liquidbounce.value.BoolValue
 import net.ccbluex.liquidbounce.value.FloatValue
 import net.minecraft.init.Blocks
 import net.minecraft.network.play.client.C07PacketPlayerDigging
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.START_DESTROY_BLOCK
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.STOP_DESTROY_BLOCK
 import net.minecraft.network.play.client.C0APacketAnimation
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
@@ -44,8 +47,8 @@ object CivBreak : Module("CivBreak", ModuleCategory.WORLD) {
         enumFacing = event.WEnumFacing ?: return
 
         // Break
-        mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.START_DESTROY_BLOCK, blockPos, enumFacing))
-        mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.STOP_DESTROY_BLOCK, blockPos, enumFacing))
+        sendPacket(C07PacketPlayerDigging(START_DESTROY_BLOCK, blockPos, enumFacing))
+        sendPacket(C07PacketPlayerDigging(STOP_DESTROY_BLOCK, blockPos, enumFacing))
     }
 
     @EventTarget
@@ -70,12 +73,12 @@ object CivBreak : Module("CivBreak", ModuleCategory.WORLD) {
                 if (visualSwingValue.get())
                     mc.thePlayer.swingItem()
                 else
-                    mc.netHandler.addToSendQueue(C0APacketAnimation())
+                    sendPacket(C0APacketAnimation())
 
                 // Break
-                mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.START_DESTROY_BLOCK,
+                sendPacket(C07PacketPlayerDigging(START_DESTROY_BLOCK,
                         blockPos, enumFacing))
-                mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.STOP_DESTROY_BLOCK,
+                sendPacket(C07PacketPlayerDigging(STOP_DESTROY_BLOCK,
                         blockPos, enumFacing))
                 mc.playerController.clickBlock(blockPos, enumFacing)
             }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Fucker.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Fucker.kt
@@ -12,6 +12,7 @@ import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.combat.KillAura
 import net.ccbluex.liquidbounce.features.module.modules.player.AutoTool
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.faceBlock
 import net.ccbluex.liquidbounce.utils.RotationUtils.setTargetRotation
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlock
@@ -26,6 +27,7 @@ import net.ccbluex.liquidbounce.value.*
 import net.minecraft.block.Block
 import net.minecraft.init.Blocks
 import net.minecraft.network.play.client.C07PacketPlayerDigging
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.*
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.Vec3
@@ -132,13 +134,13 @@ object Fucker : Module("Fucker", ModuleCategory.WORLD) {
                 // Break block
                 if (instantValue.get()) {
                     // CivBreak style block breaking
-                    mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.START_DESTROY_BLOCK,
+                    sendPacket(C07PacketPlayerDigging(START_DESTROY_BLOCK,
                             currentPos, EnumFacing.DOWN))
 
                     if (swingValue.get())
                         thePlayer.swingItem()
 
-                    mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.STOP_DESTROY_BLOCK,
+                    sendPacket(C07PacketPlayerDigging(STOP_DESTROY_BLOCK,
                             currentPos, EnumFacing.DOWN))
                     currentDamage = 0F
                     return
@@ -148,7 +150,7 @@ object Fucker : Module("Fucker", ModuleCategory.WORLD) {
                 val block = currentPos.getBlock() ?: return
 
                 if (currentDamage == 0F) {
-                    mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.START_DESTROY_BLOCK,
+                    sendPacket(C07PacketPlayerDigging(START_DESTROY_BLOCK,
                             currentPos, EnumFacing.DOWN))
 
                     if (thePlayer.capabilities.isCreativeMode ||
@@ -170,8 +172,8 @@ object Fucker : Module("Fucker", ModuleCategory.WORLD) {
                 mc.theWorld.sendBlockBreakProgress(thePlayer.entityId, currentPos, (currentDamage * 10F).toInt() - 1)
 
                 if (currentDamage >= 1F) {
-                    mc.netHandler.addToSendQueue(C07PacketPlayerDigging(
-                        C07PacketPlayerDigging.Action.STOP_DESTROY_BLOCK,
+                    sendPacket(C07PacketPlayerDigging(
+                        STOP_DESTROY_BLOCK,
                             currentPos, EnumFacing.DOWN))
                     mc.playerController.onPlayerDestroyBlock(currentPos, EnumFacing.DOWN)
                     blockHitDelay = 4

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Nuker.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Nuker.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.event.UpdateEvent
 import net.ccbluex.liquidbounce.features.module.Module
 import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.player.AutoTool
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.RotationUtils.faceBlock
 import net.ccbluex.liquidbounce.utils.RotationUtils.setTargetRotation
 import net.ccbluex.liquidbounce.utils.block.BlockUtils.getBlock
@@ -28,6 +29,7 @@ import net.minecraft.block.BlockLiquid
 import net.minecraft.init.Blocks
 import net.minecraft.item.ItemSword
 import net.minecraft.network.play.client.C07PacketPlayerDigging
+import net.minecraft.network.play.client.C07PacketPlayerDigging.Action.*
 import net.minecraft.util.BlockPos
 import net.minecraft.util.EnumFacing
 import net.minecraft.util.Vec3
@@ -148,8 +150,8 @@ object Nuker : Module("Nuker", ModuleCategory.WORLD) {
 
                 // Start block breaking
                 if (currentDamage == 0F) {
-                    mc.netHandler.addToSendQueue(
-                        C07PacketPlayerDigging(C07PacketPlayerDigging.Action.START_DESTROY_BLOCK,
+                    sendPacket(
+                        C07PacketPlayerDigging(START_DESTROY_BLOCK,
                             blockPos, EnumFacing.DOWN)
                     )
 
@@ -172,7 +174,7 @@ object Nuker : Module("Nuker", ModuleCategory.WORLD) {
 
                 // End of breaking block
                 if (currentDamage >= 1F) {
-                    mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.STOP_DESTROY_BLOCK, blockPos, EnumFacing.DOWN))
+                    sendPacket(C07PacketPlayerDigging(STOP_DESTROY_BLOCK, blockPos, EnumFacing.DOWN))
                     mc.playerController.onPlayerDestroyBlock(blockPos, EnumFacing.DOWN)
                     blockHitDelay = hitDelayValue.get()
                     currentDamage = 0F
@@ -208,10 +210,10 @@ object Nuker : Module("Nuker", ModuleCategory.WORLD) {
                     }
                     .forEach { (pos, _) ->
                         // Instant break block
-                        mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.START_DESTROY_BLOCK,
+                        sendPacket(C07PacketPlayerDigging(START_DESTROY_BLOCK,
                                 pos, EnumFacing.DOWN))
                         thePlayer.swingItem()
-                        mc.netHandler.addToSendQueue(C07PacketPlayerDigging(C07PacketPlayerDigging.Action.STOP_DESTROY_BLOCK,
+                        sendPacket(C07PacketPlayerDigging(STOP_DESTROY_BLOCK,
                                 pos, EnumFacing.DOWN))
                         attackedBlocks.add(pos)
                     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Scaffold.kt
@@ -14,6 +14,7 @@ import net.ccbluex.liquidbounce.ui.font.Fonts
 import net.ccbluex.liquidbounce.utils.InventoryUtils
 import net.ccbluex.liquidbounce.utils.MovementUtils
 import net.ccbluex.liquidbounce.utils.MovementUtils.strafe
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.PlaceRotation
 import net.ccbluex.liquidbounce.utils.Rotation
 import net.ccbluex.liquidbounce.utils.RotationUtils.getRotationDifference
@@ -251,7 +252,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
                 val shouldEagle = isReplaceable(blockPos) || dif < edgeDistanceValue.get()
                 if (eagleValue.get() == "Silent") {
                     if (eagleSneaking != shouldEagle) {
-                        mc.netHandler.addToSendQueue(
+                        sendPacket(
                             C0BPacketEntityAction(
                                 player, if (shouldEagle) {
                                     C0BPacketEntityAction.Action.START_SNEAKING
@@ -472,7 +473,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
 
                 "spoof", "switch" -> {
                     if (blockSlot - 36 != slot) {
-                        mc.netHandler.addToSendQueue(C09PacketHeldItemChange(blockSlot - 36))
+                        sendPacket(C09PacketHeldItemChange(blockSlot - 36))
                     }
                 }
             }
@@ -494,13 +495,13 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
             if (swingValue.get()) {
                 player.swingItem()
             } else {
-                mc.netHandler.addToSendQueue(C0APacketAnimation())
+                sendPacket(C0APacketAnimation())
             }
         }
 
         if (autoBlockValue.get() == "Switch") {
             if (slot != player.inventory.currentItem) {
-                mc.netHandler.addToSendQueue(C09PacketHeldItemChange(player.inventory.currentItem))
+                sendPacket(C09PacketHeldItemChange(player.inventory.currentItem))
             }
         }
 
@@ -548,7 +549,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
             if (swingValue.get()) {
                 player.swingItem()
             } else {
-                mc.netHandler.addToSendQueue(C0APacketAnimation())
+                sendPacket(C0APacketAnimation())
             }
         }
 
@@ -565,7 +566,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
         if (!GameSettings.isKeyDown(mc.gameSettings.keyBindSneak)) {
             mc.gameSettings.keyBindSneak.pressed = false
             if (eagleSneaking) {
-                mc.netHandler.addToSendQueue(
+                sendPacket(
                     C0BPacketEntityAction(
                         player, C0BPacketEntityAction.Action.STOP_SNEAKING
                     )
@@ -584,7 +585,7 @@ object Scaffold : Module("Scaffold", ModuleCategory.WORLD, keyBind = Keyboard.KE
         mc.timer.timerSpeed = 1f
 
         if (slot != player.inventory.currentItem) {
-            mc.netHandler.addToSendQueue(C09PacketHeldItemChange(player.inventory.currentItem))
+            sendPacket(C09PacketHeldItemChange(player.inventory.currentItem))
         }
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/Tower.kt
@@ -11,6 +11,7 @@ import net.ccbluex.liquidbounce.features.module.ModuleCategory
 import net.ccbluex.liquidbounce.features.module.modules.render.BlockOverlay
 import net.ccbluex.liquidbounce.ui.font.Fonts
 import net.ccbluex.liquidbounce.utils.InventoryUtils
+import net.ccbluex.liquidbounce.utils.PacketUtils.sendPacket
 import net.ccbluex.liquidbounce.utils.PlaceRotation
 import net.ccbluex.liquidbounce.utils.Rotation
 import net.ccbluex.liquidbounce.utils.RotationUtils.faceBlock
@@ -35,7 +36,7 @@ import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.renderer.GlStateManager.resetColor
 import net.minecraft.init.Blocks
 import net.minecraft.item.ItemBlock
-import net.minecraft.network.play.client.C03PacketPlayer
+import net.minecraft.network.play.client.C03PacketPlayer.C04PacketPlayerPosition
 import net.minecraft.network.play.client.C09PacketHeldItemChange
 import net.minecraft.network.play.client.C0APacketAnimation
 import net.minecraft.stats.StatList
@@ -134,7 +135,7 @@ object Tower : Module("Tower", ModuleCategory.WORLD, keyBind = Keyboard.KEY_O) {
         lockRotation = null
 
         if (slot != thePlayer.inventory.currentItem) {
-            mc.netHandler.addToSendQueue(C09PacketHeldItemChange(thePlayer.inventory.currentItem))
+            sendPacket(C09PacketHeldItemChange(thePlayer.inventory.currentItem))
         }
     }
 
@@ -212,13 +213,13 @@ object Tower : Module("Tower", ModuleCategory.WORLD, keyBind = Keyboard.KEY_O) {
 
             "packet" -> if (thePlayer.onGround && timer.hasTimePassed(2)) {
                 fakeJump()
-                mc.netHandler.addToSendQueue(
-                    C03PacketPlayer.C04PacketPlayerPosition(
+                sendPacket(
+                    C04PacketPlayerPosition(
                         thePlayer.posX, thePlayer.posY + 0.42, thePlayer.posZ, false
                     )
                 )
-                mc.netHandler.addToSendQueue(
-                    C03PacketPlayer.C04PacketPlayerPosition(
+                sendPacket(
+                    C04PacketPlayerPosition(
                         thePlayer.posX, thePlayer.posY + 0.753, thePlayer.posZ, false
                     )
                 )
@@ -300,13 +301,13 @@ object Tower : Module("Tower", ModuleCategory.WORLD, keyBind = Keyboard.KEY_O) {
 
                 "Spoof" -> {
                     if (blockSlot - 36 != slot) {
-                        mc.netHandler.addToSendQueue(C09PacketHeldItemChange(blockSlot - 36))
+                        sendPacket(C09PacketHeldItemChange(blockSlot - 36))
                     }
                 }
 
                 "Switch" -> {
                     if (blockSlot - 36 != slot) {
-                        mc.netHandler.addToSendQueue(C09PacketHeldItemChange(blockSlot - 36))
+                        sendPacket(C09PacketHeldItemChange(blockSlot - 36))
                     }
                 }
             }
@@ -321,11 +322,11 @@ object Tower : Module("Tower", ModuleCategory.WORLD, keyBind = Keyboard.KEY_O) {
             if (swingValue.get()) {
                 thePlayer.swingItem()
             } else {
-                mc.netHandler.addToSendQueue(C0APacketAnimation())
+                sendPacket(C0APacketAnimation())
             }
         }
         if (autoBlockValue.get() == "Switch" && slot != mc.thePlayer.inventory.currentItem)
-            mc.netHandler.addToSendQueue(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
+            sendPacket(C09PacketHeldItemChange(mc.thePlayer.inventory.currentItem))
 
         placeInfo = null
     }

--- a/src/main/java/net/ccbluex/liquidbounce/utils/PacketUtils.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/PacketUtils.kt
@@ -5,201 +5,50 @@
  */
 package net.ccbluex.liquidbounce.utils
 
+import net.ccbluex.liquidbounce.utils.PacketUtils.realMotionX
 import net.minecraft.network.Packet
 import net.minecraft.network.play.INetHandlerPlayClient
-import net.minecraft.network.play.INetHandlerPlayServer
 import net.minecraft.network.play.server.*
+import kotlin.math.roundToInt
 
 object PacketUtils : MinecraftInstance() {
-    private val packets = ArrayList<Packet<INetHandlerPlayServer>>()
+    var triggerEvent = true
 
-    fun handleSendPacket(packet: Packet<*>): Boolean {
-        if (packets.contains(packet)) {
-            packets.remove(packet)
-            return true
-        }
-        return false
-    }
-
-    val S12PacketEntityVelocity.realMotionX: Float
+    var S12PacketEntityVelocity.realMotionX: Float
         get() = motionX / 8000f
+        set(value) {
+            motionX = (value * 8000f).roundToInt()
+        }
 
-    val S12PacketEntityVelocity.realMotionY: Float
+    var S12PacketEntityVelocity.realMotionY: Float
         get() = motionY / 8000f
+        set(value) {
+            motionX = (value * 8000f).roundToInt()
+        }
 
-    val S12PacketEntityVelocity.realMotionZ: Float
+    var S12PacketEntityVelocity.realMotionZ: Float
         get() = motionZ / 8000f
-
-    @JvmStatic
-    fun sendPacketNoEvent(packet: Packet<INetHandlerPlayServer>) {
-        packets.add(packet)
-        mc.netHandler.addToSendQueue(packet)
-    }
-
-    fun handlePacket(packet: Packet<INetHandlerPlayClient?>) {
-        val netHandler = mc.netHandler
-
-        if (packet is S00PacketKeepAlive) {
-            netHandler.handleKeepAlive(packet)
-        } else if (packet is S01PacketJoinGame) {
-            netHandler.handleJoinGame(packet)
-        } else if (packet is S02PacketChat) {
-            netHandler.handleChat(packet)
-        } else if (packet is S03PacketTimeUpdate) {
-            netHandler.handleTimeUpdate(packet)
-        } else if (packet is S04PacketEntityEquipment) {
-            netHandler.handleEntityEquipment(packet)
-        } else if (packet is S05PacketSpawnPosition) {
-            netHandler.handleSpawnPosition(packet)
-        } else if (packet is S06PacketUpdateHealth) {
-            netHandler.handleUpdateHealth(packet)
-        } else if (packet is S07PacketRespawn) {
-            netHandler.handleRespawn(packet)
-        } else if (packet is S08PacketPlayerPosLook) {
-            netHandler.handlePlayerPosLook(packet)
-        } else if (packet is S09PacketHeldItemChange) {
-            netHandler.handleHeldItemChange(packet)
-        } else if (packet is S10PacketSpawnPainting) {
-            netHandler.handleSpawnPainting(packet)
-        } else if (packet is S0APacketUseBed) {
-            netHandler.handleUseBed(packet)
-        } else if (packet is S0BPacketAnimation) {
-            netHandler.handleAnimation(packet)
-        } else if (packet is S0CPacketSpawnPlayer) {
-            netHandler.handleSpawnPlayer(packet)
-        } else if (packet is S0DPacketCollectItem) {
-            netHandler.handleCollectItem(packet)
-        } else if (packet is S0EPacketSpawnObject) {
-            netHandler.handleSpawnObject(packet)
-        } else if (packet is S0FPacketSpawnMob) {
-            netHandler.handleSpawnMob(packet)
-        } else if (packet is S11PacketSpawnExperienceOrb) {
-            netHandler.handleSpawnExperienceOrb(packet)
-        } else if (packet is S12PacketEntityVelocity) {
-            netHandler.handleEntityVelocity(packet)
-        } else if (packet is S13PacketDestroyEntities) {
-            netHandler.handleDestroyEntities(packet)
-        } else if (packet is S14PacketEntity) {
-            netHandler.handleEntityMovement(packet)
-        } else if (packet is S18PacketEntityTeleport) {
-            netHandler.handleEntityTeleport(packet)
-        } else if (packet is S19PacketEntityStatus) {
-            netHandler.handleEntityStatus(packet)
-        } else if (packet is S19PacketEntityHeadLook) {
-            netHandler.handleEntityHeadLook(packet)
-        } else if (packet is S1BPacketEntityAttach) {
-            netHandler.handleEntityAttach(packet)
-        } else if (packet is S1CPacketEntityMetadata) {
-            netHandler.handleEntityMetadata(packet)
-        } else if (packet is S1DPacketEntityEffect) {
-            netHandler.handleEntityEffect(packet)
-        } else if (packet is S1EPacketRemoveEntityEffect) {
-            netHandler.handleRemoveEntityEffect(packet)
-        } else if (packet is S1FPacketSetExperience) {
-            netHandler.handleSetExperience(packet)
-        } else if (packet is S20PacketEntityProperties) {
-            netHandler.handleEntityProperties(packet)
-        } else if (packet is S21PacketChunkData) {
-            netHandler.handleChunkData(packet)
-        } else if (packet is S22PacketMultiBlockChange) {
-            netHandler.handleMultiBlockChange(packet)
-        } else if (packet is S23PacketBlockChange) {
-            netHandler.handleBlockChange(packet)
-        } else if (packet is S24PacketBlockAction) {
-            netHandler.handleBlockAction(packet)
-        } else if (packet is S25PacketBlockBreakAnim) {
-            netHandler.handleBlockBreakAnim(packet)
-        } else if (packet is S26PacketMapChunkBulk) {
-            netHandler.handleMapChunkBulk(packet)
-        } else if (packet is S27PacketExplosion) {
-            netHandler.handleExplosion(packet)
-        } else if (packet is S28PacketEffect) {
-            netHandler.handleEffect(packet)
-        } else if (packet is S29PacketSoundEffect) {
-            netHandler.handleSoundEffect(packet)
-        } else if (packet is S2APacketParticles) {
-            netHandler.handleParticles(packet)
-        } else if (packet is S2BPacketChangeGameState) {
-            netHandler.handleChangeGameState(packet)
-        } else if (packet is S2CPacketSpawnGlobalEntity) {
-            netHandler.handleSpawnGlobalEntity(packet)
-        } else if (packet is S2DPacketOpenWindow) {
-            netHandler.handleOpenWindow(packet)
-        } else if (packet is S2EPacketCloseWindow) {
-            netHandler.handleCloseWindow(packet)
-        } else if (packet is S2FPacketSetSlot) {
-            netHandler.handleSetSlot(packet)
-        } else if (packet is S30PacketWindowItems) {
-            netHandler.handleWindowItems(packet)
-        } else if (packet is S31PacketWindowProperty) {
-            netHandler.handleWindowProperty(packet)
-        } else if (packet is S32PacketConfirmTransaction) {
-            netHandler.handleConfirmTransaction(packet)
-        } else if (packet is S33PacketUpdateSign) {
-            netHandler.handleUpdateSign(packet)
-        } else if (packet is S34PacketMaps) {
-            netHandler.handleMaps(packet)
-        } else if (packet is S35PacketUpdateTileEntity) {
-            netHandler.handleUpdateTileEntity(packet)
-        } else if (packet is S36PacketSignEditorOpen) {
-            netHandler.handleSignEditorOpen(packet)
-        } else if (packet is S37PacketStatistics) {
-            netHandler.handleStatistics(packet)
-        } else if (packet is S38PacketPlayerListItem) {
-            netHandler.handlePlayerListItem(packet)
-        } else if (packet is S39PacketPlayerAbilities) {
-            netHandler.handlePlayerAbilities(packet)
-        } else if (packet is S3APacketTabComplete) {
-            netHandler.handleTabComplete(packet)
-        } else if (packet is S3BPacketScoreboardObjective) {
-            netHandler.handleScoreboardObjective(packet)
-        } else if (packet is S3CPacketUpdateScore) {
-            netHandler.handleUpdateScore(packet)
-        } else if (packet is S3DPacketDisplayScoreboard) {
-            netHandler.handleDisplayScoreboard(packet)
-        } else if (packet is S3EPacketTeams) {
-            netHandler.handleTeams(packet)
-        } else if (packet is S3FPacketCustomPayload) {
-            netHandler.handleCustomPayload(packet)
-        } else if (packet is S40PacketDisconnect) {
-            netHandler.handleDisconnect(packet)
-        } else if (packet is S41PacketServerDifficulty) {
-            netHandler.handleServerDifficulty(packet)
-        } else if (packet is S42PacketCombatEvent) {
-            netHandler.handleCombatEvent(packet)
-        } else if (packet is S43PacketCamera) {
-            netHandler.handleCamera(packet)
-        } else if (packet is S44PacketWorldBorder) {
-            netHandler.handleWorldBorder(packet)
-        } else if (packet is S45PacketTitle) {
-            netHandler.handleTitle(packet)
-        } else if (packet is S46PacketSetCompressionLevel) {
-            netHandler.handleSetCompressionLevel(packet)
-        } else if (packet is S47PacketPlayerListHeaderFooter) {
-            netHandler.handlePlayerListHeaderFooter(packet)
-        } else if (packet is S48PacketResourcePackSend) {
-            netHandler.handleResourcePack(packet)
-        } else if (packet is S49PacketUpdateEntityNBT) {
-            netHandler.handleEntityNBT(packet)
-        } else {
-            throw IllegalArgumentException("Unable to match packet type to handle: ${packet.javaClass}")
-        }
-    }
-
-    fun getPacketType(packet: Packet<*>): PacketType {
-        val className = packet.javaClass.simpleName
-        if (className.startsWith("C", ignoreCase = true)) {
-                return PacketType.CLIENTSIDE
-        } else if (className.startsWith("S", ignoreCase = true)) {
-                return PacketType.SERVERSIDE
+        set(value) {
+            motionX = (value * 8000f).roundToInt()
         }
 
-        return PacketType.UNKNOWN
+    fun sendPacket(packet: Packet<*>, triggerEvent: Boolean = true) {
+        this.triggerEvent = triggerEvent
+        sendPacket(packet)
     }
+
+    fun handlePacket(packet: Packet<INetHandlerPlayClient>?) = packet?.processPacket(mc.netHandler)
+
+    val Packet<*>.type
+        get() = when (this.javaClass.simpleName[0]) {
+            'C' -> PacketType.CLIENT
+            'S' -> PacketType.SERVER
+            else -> PacketType.UNKNOWN
+        }
 
     enum class PacketType {
-        SERVERSIDE,
-        CLIENTSIDE,
+        SERVER,
+        CLIENT,
         UNKNOWN
     }
 }


### PR DESCRIPTION
PacketUtils:
* sendPacketNoEvent -> sendPacket(packet, triggerEvent = true)
* significantly simplified handlePacket
* getPacketType -> Packet.type extension
* added setters to S12PacketEntityVelocity

Reworked how event is prevented from getting called.
* MixinNetworkManager

PacketEvent:
* eventState - EventState.SEND, EventState.RECEIVE

Implemented sendPacket to all modules.

Simplified packets in all modules
* C03PacketPlayer.C04PacketPlayerPosition... to just C04PacketPlayerPosition
* C07PacketPlayerDigging.Action.RELEASE_USE_ITEM/... to RELEASE_USE_ITEM/...
* C16PacketClientStatus.EnumState.OPEN_INVENTORY_ACHIEVEMENT to OPEN_INVENTORY_ACHIEVEMENT